### PR TITLE
Move script registration to manifest file.

### DIFF
--- a/background.js
+++ b/background.js
@@ -182,18 +182,10 @@ browser.webRequest.onBeforeRequest.addListener(
             const url = `${details.initiator || details.url}/`;
             browser.tabs.query({ url }, (tabs) => {
               tabs.forEach((tab) => {
-                browser.scripting.executeScript(
-                  {
-                    target: { tabId: tab.id },
-                    files: ['contentInject.js'],
-                  },
-                  () => {
-                    browser.tabs.sendMessage(tab.id, {
-                      type: 'store-results',
-                      data: Object.fromEntries(detectedAPIs),
-                    });
-                  },
-                );
+                browser.tabs.sendMessage(tab.id, {
+                  type: 'store-results',
+                  data: Object.fromEntries(detectedAPIs),
+                });
                 updatePopup(url);
               });
             });
@@ -221,18 +213,10 @@ browser.webNavigation.onCompleted.addListener(({ url, tabId, frameId }) => {
   if (detectedAPIs.size) {
     browser.tabs.query({ url }, (tabs) => {
       tabs.forEach((tab) => {
-        browser.scripting.executeScript(
-          {
-            target: { tabId },
-            files: ['contentInject.js'],
-          },
-          () => {
-            browser.tabs.sendMessage(tab.id, {
-              type: 'store-results',
-              data: Object.fromEntries(detectedAPIs),
-            });
-          },
-        );
+        browser.tabs.sendMessage(tab.id, {
+          type: 'store-results',
+          data: Object.fromEntries(detectedAPIs),
+        });
         console.log(detectedAPIs.entries());
         updatePopup(url);
       });

--- a/manifest.json
+++ b/manifest.json
@@ -16,6 +16,13 @@
     },
     "default_title": "__MSG_noAPIsDetected__"
   },
+  "content_scripts": [
+    {
+      "js": ["contentInject.js"],
+      "matches": ["<all_urls>"],
+      "run_at": "document_start"
+    }
+  ],
   "icons": {
     "320": "./assets/blowfish.png"
   }


### PR DESCRIPTION
Avoids an issue where the content script was injected multiple times, once for each subrequest, by injecting the content script via. the manifest file.

This fixes a small UI bug where the popup could receive multiple responses. This would trigger the screenshot logic more than once and in turn create several duplicates of the content for a short period of time.